### PR TITLE
Updated URL for CRAN binaries

### DIFF
--- a/ubuntu/install_R.sh
+++ b/ubuntu/install_R.sh
@@ -2,7 +2,7 @@
 #R
 
 # Add sources entry & apt key
-sudo sh -c 'echo "deb http://cran.rstudio.com/bin/linux/ubuntu trusty/" >> /etc/apt/sources.list'
+sudo sh -c 'echo "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/" >> /etc/apt/sources.list'
 gpg --keyserver keyserver.ubuntu.com --recv-key E084DAB9
 gpg -a --export E084DAB9 | sudo apt-key add -
 


### PR DESCRIPTION
Using URL given at https://cran.rstudio.com, which includes call to lsb_release to get correct Ubuntu version.